### PR TITLE
Strip symbols from object files and executables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ rust:
 	cd rs && \
 	cargo test && \
 	cargo build --release && \
+	strip target/release/librust_atomics.{a,rlib} && \
 	cbindgen --output rust-atomics.h
 
 clean:

--- a/rs/Cargo.toml
+++ b/rs/Cargo.toml
@@ -19,6 +19,7 @@ libc = "0.2.170"
 panic = "abort"
 lto = true
 codegen-units = 1
+strip = true
 
 [[bin]]
 bench = false


### PR DESCRIPTION
If removing symbols is acceptable, stripping them can reduce total object file size by around 35%. This helps with #2, optimizing build size.

With symbols:
```sh
364K    rs/target/release/mpmc_queue
 16M    rs/target/release/librust_atomics.a
264K    rs/target/release/librust_atomics.rlib
```

Without symbols:
```sh
316K    rs/target/release/mpmc_queue
 10M    rs/target/release/librust_atomics.a
220K    rs/target/release/librust_atomics.rlib
```