### PR TITLE
Implement `Ratomic::Map#size`

### DIFF
--- a/ext/ratomic/hashmap.h
+++ b/ext/ratomic/hashmap.h
@@ -53,6 +53,13 @@ VALUE rb_concurrent_hash_map_clear(VALUE self) {
   return Qnil;
 }
 
+VALUE rb_concurrent_hash_map_size(VALUE self) {
+  concurrent_hash_map_t *hashmap;
+  TypedData_Get_Struct(self, concurrent_hash_map_t, &concurrent_hash_map_data,
+                       hashmap);
+  return LONG2FIX(concurrent_hash_map_size(hashmap));
+}
+
 VALUE rb_concurrent_hash_map_fetch_and_modify(VALUE self, VALUE key) {
   rb_need_block();
   concurrent_hash_map_t *hashmap;
@@ -69,6 +76,7 @@ static void init_hashmap(VALUE rb_mRoot) {
   rb_define_method(rb_cConcurrentHashMap, "get", rb_concurrent_hash_map_get, 1);
   rb_define_method(rb_cConcurrentHashMap, "set", rb_concurrent_hash_map_set, 2);
   rb_define_method(rb_cConcurrentHashMap, "clear", rb_concurrent_hash_map_clear, 0);
+  rb_define_method(rb_cConcurrentHashMap, "size", rb_concurrent_hash_map_size, 0);
   rb_define_method(rb_cConcurrentHashMap, "fetch_and_modify",
                    rb_concurrent_hash_map_fetch_and_modify, 1);
 }

--- a/rs/rust-atomics.h
+++ b/rs/rust-atomics.h
@@ -45,6 +45,8 @@ void concurrent_hash_map_drop(concurrent_hash_map_t *hashmap);
 
 void concurrent_hash_map_clear(const concurrent_hash_map_t *hashmap);
 
+size_t concurrent_hash_map_size(const concurrent_hash_map_t *hashmap);
+
 unsigned long concurrent_hash_map_get(const concurrent_hash_map_t *hashmap,
                                       unsigned long key,
                                       unsigned long fallback);

--- a/rs/src/hashmap.rs
+++ b/rs/src/hashmap.rs
@@ -47,6 +47,10 @@ impl ConcurrentHashMap {
         self.map.clear()
     }
 
+    fn size(&self) -> usize {
+        self.map.len()
+    }
+
     fn fetch_and_modify(&self, key: c_ulong, f: extern "C" fn(c_ulong) -> c_ulong) {
         let key = RubyHashEql(key);
         self.map.alter(&key, |_, v| f(v));
@@ -74,6 +78,12 @@ pub unsafe extern "C" fn concurrent_hash_map_drop(hashmap: *mut ConcurrentHashMa
 pub unsafe extern "C" fn concurrent_hash_map_clear(hashmap: *const ConcurrentHashMap) {
     let hashmap = unsafe { hashmap.as_ref().unwrap() };
     hashmap.clear();
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn concurrent_hash_map_size(hashmap: *const ConcurrentHashMap) -> usize {
+    let hashmap = unsafe { hashmap.as_ref().unwrap() };
+    hashmap.size()
 }
 
 #[unsafe(no_mangle)]

--- a/test/test_hash_map.rb
+++ b/test/test_hash_map.rb
@@ -4,6 +4,7 @@ class TestHashMap < Minitest::Test
   MAP = Ratomic::Map.new
 
   def test_ractor_hashing
+    MAP.clear
     cpus = Etc.nprocessors
     iter = 100000
     ractors = 1.upto(cpus).map do |i|
@@ -18,5 +19,10 @@ class TestHashMap < Minitest::Test
       assert_equal iter+idx, MAP.get(idx)
       assert_equal iter+idx, MAP[idx]
     end
+  end
+
+  def test_size
+    MAP.clear
+    assert_equal 123, MAP.size
   end
 end

--- a/test/test_hash_map.rb
+++ b/test/test_hash_map.rb
@@ -31,4 +31,19 @@ class TestHashMap < Minitest::Test
     MAP.clear
     assert_equal 0, MAP.size
   end
+
+  def test_size_with_ractors
+    MAP.clear
+    cpus = Etc.nprocessors
+    iter = 100_000
+    ractors = 1.upto(cpus).map do |i|
+      Ractor.new(iter) do |iter|
+        iter.times { |idx| MAP[idx] = (iter + idx) }
+        Ractor.yield :done
+      end
+    end
+    ractors.map(&:take)
+
+    assert_equal 100_000, MAP.size
+  end
 end

--- a/test/test_hash_map.rb
+++ b/test/test_hash_map.rb
@@ -21,8 +21,14 @@ class TestHashMap < Minitest::Test
     end
   end
 
-  def test_size
+  def test_size_no_ractors
     MAP.clear
-    assert_equal 123, MAP.size
+    assert_equal 0, MAP.size
+    MAP.set(1, 2)
+    assert_equal 1, MAP.size
+    MAP.set(2, 3)
+    assert_equal 2, MAP.size
+    MAP.clear
+    assert_equal 0, MAP.size
   end
 end


### PR DESCRIPTION
My colleague @oliverbarnes and I are dipping our toes into this project, and here's a first PR.

As per the title of the PR, this implements a `size` method for `Ratomic::Map`. The implementation is straightforward (or so we think), working from the already implemented methods. 