### PR TITLE
Add some QOL methods to Ratomic::Queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## [Unreleased]
+- Add `length`, `size`, `peek` and `empty?` methods to Ratomic::Queue
 
 ## [0.1.0] - 2025-03-20
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ item = q.pop # => "world"
 q.empty?   # => true
 ```
 
+Since `Ratomic::Queue` is a concurrent queue, the `size`, `empty?`, and `peek` methods provide only a best-effort guess — the values they return might be stale or incorrect.
+
 ## Thanks
 
 [Ilya Bylich](https://github.com/iliabylich) wrote and documented his original research at [Ruby, Ractors, and Lock-free Data Structures/](https://iliabylich.github.io/ruby-ractors-and-lock-free-data-structures/).

--- a/README.md
+++ b/README.md
@@ -79,9 +79,17 @@ HASH.clear
 A multi-producer, multi-consumer queue.
 
 ```ruby
-q = Ratomic::Queue.new
-q.push(Object.new)
-q.pop # => <Object>
+q = Ratomic::Queue.new(128) 
+
+q.push("hello")
+q.push("world")
+
+q.size     # => 2
+q.empty?   # => false
+q.peek     # => "hello"
+item = q.pop # => "hello"
+item = q.pop # => "world"
+q.empty?   # => true
 ```
 
 ## Thanks

--- a/ext/ratomic/mpmc-queue.h
+++ b/ext/ratomic/mpmc-queue.h
@@ -57,6 +57,18 @@ VALUE rb_mpmc_queue_pop(VALUE self) {
   return item;
 }
 
+VALUE rb_mpmc_queue_peek(VALUE self) {
+  mpmc_queue_t *queue;
+  TypedData_Get_Struct(self, mpmc_queue_t, &mpmc_queue_data, queue);
+  void *ptr = rb_thread_call_without_gvl(mpmc_queue_peek, queue, NULL, NULL);
+
+  if (ptr == NULL) {
+    return Qnil;
+  }
+  VALUE item = (VALUE)ptr;
+  return item;
+}
+
 VALUE rb_mpmc_queue_is_empty(VALUE self) {
   mpmc_queue_t *queue;
   TypedData_Get_Struct(self, mpmc_queue_t, &mpmc_queue_data, queue);
@@ -81,6 +93,7 @@ static void init_mpmc_queue(VALUE rb_mRoot) {
   rb_define_method(rb_cMpmcQueue, "initialize", rb_mpmc_queue_initialize, 1);
   rb_define_method(rb_cMpmcQueue, "push", rb_mpmc_queue_push, 1);
   rb_define_method(rb_cMpmcQueue, "pop", rb_mpmc_queue_pop, 0);
+  rb_define_method(rb_cMpmcQueue, "peek", rb_mpmc_queue_peek, 0);
   rb_define_method(rb_cMpmcQueue, "empty?", rb_mpmc_queue_is_empty, 0); 
   rb_define_method(rb_cMpmcQueue, "length", rb_mpmc_queue_size, 0);
   rb_define_alias(rb_cMpmcQueue, "size", "length");

--- a/ext/ratomic/mpmc-queue.h
+++ b/ext/ratomic/mpmc-queue.h
@@ -65,6 +65,14 @@ VALUE rb_mpmc_queue_is_empty(VALUE self) {
   return is_empty ? Qtrue : Qfalse;
 }
 
+VALUE rb_mpmc_queue_size(VALUE self) {
+  mpmc_queue_t *queue;
+  TypedData_Get_Struct(self, mpmc_queue_t, &mpmc_queue_data, queue);
+  void *ptr = rb_thread_call_without_gvl(mpmc_queue_size, queue, NULL, NULL);
+  size_t size = (size_t)ptr;
+  return LONG2NUM(size);
+}
+
 static void init_mpmc_queue(VALUE rb_mRoot) {
   VALUE rb_cMpmcQueue =
       rb_define_class_under(rb_mRoot, "Queue", rb_cObject);
@@ -74,4 +82,6 @@ static void init_mpmc_queue(VALUE rb_mRoot) {
   rb_define_method(rb_cMpmcQueue, "push", rb_mpmc_queue_push, 1);
   rb_define_method(rb_cMpmcQueue, "pop", rb_mpmc_queue_pop, 0);
   rb_define_method(rb_cMpmcQueue, "empty?", rb_mpmc_queue_is_empty, 0); 
+  rb_define_method(rb_cMpmcQueue, "length", rb_mpmc_queue_size, 0);
+  rb_define_alias(rb_cMpmcQueue, "size", "length");
 }

--- a/ext/ratomic/mpmc-queue.h
+++ b/ext/ratomic/mpmc-queue.h
@@ -57,6 +57,14 @@ VALUE rb_mpmc_queue_pop(VALUE self) {
   return item;
 }
 
+VALUE rb_mpmc_queue_is_empty(VALUE self) {
+  mpmc_queue_t *queue;
+  TypedData_Get_Struct(self, mpmc_queue_t, &mpmc_queue_data, queue);
+  void *ptr = rb_thread_call_without_gvl(mpmc_queue_is_empty, queue, NULL, NULL);
+  VALUE is_empty = (VALUE)ptr;
+  return is_empty ? Qtrue : Qfalse;
+}
+
 static void init_mpmc_queue(VALUE rb_mRoot) {
   VALUE rb_cMpmcQueue =
       rb_define_class_under(rb_mRoot, "Queue", rb_cObject);
@@ -65,4 +73,5 @@ static void init_mpmc_queue(VALUE rb_mRoot) {
   rb_define_method(rb_cMpmcQueue, "initialize", rb_mpmc_queue_initialize, 1);
   rb_define_method(rb_cMpmcQueue, "push", rb_mpmc_queue_push, 1);
   rb_define_method(rb_cMpmcQueue, "pop", rb_mpmc_queue_pop, 0);
+  rb_define_method(rb_cMpmcQueue, "empty?", rb_mpmc_queue_is_empty, 0); 
 }

--- a/rs/rust-atomics.h
+++ b/rs/rust-atomics.h
@@ -88,4 +88,6 @@ void *mpmc_queue_push(void *push_paylod);
 
 void *mpmc_queue_pop(void *q);
 
+void *mpmc_queue_is_empty(void *q);
+
 #endif  /* RUST_ATOMICS_H */

--- a/rs/rust-atomics.h
+++ b/rs/rust-atomics.h
@@ -90,4 +90,6 @@ void *mpmc_queue_pop(void *q);
 
 void *mpmc_queue_is_empty(void *q);
 
+void *mpmc_queue_size(void *q);
+
 #endif  /* RUST_ATOMICS_H */

--- a/rs/rust-atomics.h
+++ b/rs/rust-atomics.h
@@ -88,6 +88,8 @@ void *mpmc_queue_push(void *push_paylod);
 
 void *mpmc_queue_pop(void *q);
 
+void *mpmc_queue_peek(void *q);
+
 void *mpmc_queue_is_empty(void *q);
 
 void *mpmc_queue_size(void *q);

--- a/rs/src/mpmc_queue.rs
+++ b/rs/src/mpmc_queue.rs
@@ -146,6 +146,18 @@ impl MpmcQueue {
         }
     }
 
+    pub fn peek(&self) -> Option<c_ulong> {
+        let pos = self.dequeue_pos.load(Ordering::Relaxed);
+        let cell = &self.buffer[pos & self.buffer_mask];
+        let seq = cell.sequence.load(Ordering::Acquire);
+        let diff = seq as isize - (pos + 1) as isize;
+        if diff == 0 {
+            Some(cell.data.get())
+        } else {
+            None
+        }
+    }
+
     pub fn is_empty(&self) -> bool {
         self.dequeue_pos.load(Ordering::Relaxed) == self.enqueue_pos.load(Ordering::Relaxed)
     }
@@ -223,6 +235,16 @@ pub unsafe extern "C" fn mpmc_queue_pop(q: *mut std::ffi::c_void) -> *mut std::f
     let q = unsafe { q.cast::<MpmcQueue>().as_ref().unwrap() };
     let item = q.pop();
     unsafe { std::mem::transmute(item) }
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn mpmc_queue_peek(q: *mut std::ffi::c_void) -> *mut std::ffi::c_void {
+    let q = unsafe { q.cast::<MpmcQueue>().as_ref().unwrap() };
+    let item = q.peek();
+    if let Some(item) = item {
+        return unsafe { std::mem::transmute(item) };
+    }
+    std::ptr::null_mut()
 }
 
 #[unsafe(no_mangle)]

--- a/rs/src/mpmc_queue.rs
+++ b/rs/src/mpmc_queue.rs
@@ -146,6 +146,10 @@ impl MpmcQueue {
         }
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.dequeue_pos.load(Ordering::Relaxed) == self.enqueue_pos.load(Ordering::Relaxed)
+    }
+
     pub fn acquire_as_gc<F, T>(&self, f: F) -> T
     where
         F: FnOnce() -> T,
@@ -215,6 +219,12 @@ pub unsafe extern "C" fn mpmc_queue_pop(q: *mut std::ffi::c_void) -> *mut std::f
     let q = unsafe { q.cast::<MpmcQueue>().as_ref().unwrap() };
     let item = q.pop();
     unsafe { std::mem::transmute(item) }
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn mpmc_queue_is_empty(q: *mut std::ffi::c_void) -> bool {
+  let q = unsafe { q.cast::<MpmcQueue>().as_ref().unwrap() };
+  q.is_empty()
 }
 
 pub const MPMC_QUEUE_OBJECT_SIZE: usize = 80;

--- a/rs/src/mpmc_queue.rs
+++ b/rs/src/mpmc_queue.rs
@@ -150,6 +150,10 @@ impl MpmcQueue {
         self.dequeue_pos.load(Ordering::Relaxed) == self.enqueue_pos.load(Ordering::Relaxed)
     }
 
+    pub fn size(&self) -> usize {
+        self.enqueue_pos.load(Ordering::Relaxed).wrapping_sub(self.dequeue_pos.load(Ordering::Relaxed))
+    }
+
     pub fn acquire_as_gc<F, T>(&self, f: F) -> T
     where
         F: FnOnce() -> T,
@@ -225,6 +229,12 @@ pub unsafe extern "C" fn mpmc_queue_pop(q: *mut std::ffi::c_void) -> *mut std::f
 pub unsafe extern "C" fn mpmc_queue_is_empty(q: *mut std::ffi::c_void) -> bool {
   let q = unsafe { q.cast::<MpmcQueue>().as_ref().unwrap() };
   q.is_empty()
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn mpmc_queue_size(q: *mut std::ffi::c_void) -> usize {
+    let q = unsafe { q.cast::<MpmcQueue>().as_ref().unwrap() };
+    q.size()
 }
 
 pub const MPMC_QUEUE_OBJECT_SIZE: usize = 80;

--- a/test/test_queue.rb
+++ b/test/test_queue.rb
@@ -1,0 +1,114 @@
+require "test_helper"
+
+class TestMpmcQueue < Minitest::Test
+  QUEUE_CAPACITY = 128  
+  TOTAL_ITEMS = 50
+
+  def setup
+    @queue = Ratomic::Queue.new(QUEUE_CAPACITY)
+  end
+
+  def test_basic_operations
+    assert @queue.empty?, "initial queue should be empty"
+    assert_equal 0, @queue.size, "initial size should be 0"
+    assert_nil @queue.peek, "peek on empty queue should be nil"
+
+    @queue.push(:a)
+    refute @queue.empty?, "queue should not be empty after push"
+    assert_equal 1, @queue.size, "size should be 1 after push"
+    assert_equal :a, @queue.peek, "peek should return the pushed item"
+    assert_equal 1, @queue.size, "size should be unchanged after peek" 
+
+    item = @queue.pop
+    assert_equal :a, item, "pop should return the pushed item"
+    assert @queue.empty?, "queue should be empty after pop"
+    assert_equal 0, @queue.size, "size should be 0 after pop"
+  end
+
+  def test_pop_waits_for_item
+    blocker = Ractor.new(@queue) { |q| q.pop }
+
+    sleep 0.05
+
+    # There is currently no public API to check the status of a Ractor
+    assert blocker.inspect.include?("blocking"), "should be blocked waiting for pop"
+
+    @queue.push(123)
+    result = nil
+    50.times { result = blocker.take rescue nil; break if result; sleep 0.01 }
+
+    assert_equal 123, result, "did not receive the pushed item"
+  end
+
+  def test_push_waits_for_free_space
+    QUEUE_CAPACITY.times { |i| @queue.push("fill_#{i}") }
+    assert_equal QUEUE_CAPACITY, @queue.size
+
+    blocker = Ractor.new(@queue) do |q|
+      q.push("extra")
+      :pushed 
+    end
+
+    assert blocker.inspect.include?("blocking"), "should be blocked waiting for free space"
+
+    @queue.pop
+
+    result = nil
+    50.times { result = blocker.take rescue nil; break if result; sleep 0.01 } 
+    assert_equal :pushed, result, "did not signal successful push"
+
+    remaining_items = []
+    QUEUE_CAPACITY.times { remaining_items << @queue.pop } 
+    assert_includes remaining_items, "extra", "'extra' item pushed by the Ractor was not found"
+  end
+
+  def test_mpmc_concurrent_transfer
+    num_producers = Etc.nprocessors / 2
+    num_consumers = Etc.nprocessors / 2
+    items_per_producer = (TOTAL_ITEMS.to_f / num_producers).ceil 
+    actual_total_items = items_per_producer * num_producers 
+
+    producers = num_producers.times.map do |p_idx|
+      Ractor.new(@queue, items_per_producer, p_idx) do |q, count, id|
+        start_num = id * count
+        count.times do |i|
+          q.push(start_num + i)
+        end
+        :done_producing
+      end
+    end
+
+    consumers = num_consumers.times.map do
+      Ractor.new(@queue) do |q|
+        loop do
+          item = q.pop
+          break if item == :__TERMINATE__ 
+          Ractor.yield item
+        end
+      end
+    end
+
+    sleep 0.1
+
+    producers.each { |p| assert_equal :done_producing, p.take }
+
+    results = []
+    actual_total_items.times do |i|
+      _, value = Ractor.select(*consumers)
+      results << value
+    rescue Ractor::ClosedError, Ractor::RemoteError, Ractor::Error => e
+      flunk "consumer Ractor closed unexpectedly: #{e.message}"
+      break
+    end
+
+    num_consumers.times do
+      @queue.push(:__TERMINATE__)
+    end
+
+    assert_equal actual_total_items, results.size, "did not receive the expected number of items"
+    assert_equal (0...actual_total_items).to_a, results.sort, "set of popped items does not match the set of pushed items"
+
+    assert @queue.empty?, "queue should be empty after items are popped. Size: #{@queue.size}"
+    assert_equal 0, @queue.size
+  end
+end


### PR DESCRIPTION
I've been using this in a couple of proof-of-concept projects and I've been missing some of the usually available methods on standard Queues. 

This PR adds a couple of new methods to `Ratomic::Queue`:

- `length` (and `size` alias)
- `empty?`
- `peek`