### PR TITLE
Raise on invalid queue capacity instead of crashing on Rust assertions

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ HASH.clear
 A multi-producer, multi-consumer queue.
 
 ```ruby
-q = Ratomic::Queue.new(128) # capacity must be a power of 2 and at least 2
+q = Ratomic::Queue.new(128)
 
 q.push("hello")
 q.push("world")
@@ -91,7 +91,9 @@ item = q.pop # => "hello"
 item = q.pop # => "world"
 q.empty?   # => true
 ```
-The `.new(capacity)` method initializes the queue with a fixed-size buffer. The capacity must be a power of 2 and at least 2, which ensures efficient indexing and wrap-around in the underlying buffer
+The `.new(capacity)` method initializes the queue with a fixed-size buffer. The capacity must be greater than or equal to 1 and less than or equal to 2<sup>20</sup>.
+
+Values that are not a power of two are rounded up to the nearest greater power of two, which enables efficient indexing and wrap-around calculations in the underlying buffer.
 
 Since `Ratomic::Queue` is a concurrent queue, the `size`, `empty?`, and `peek` methods provide only a best-effort guess — the values they return might be stale or incorrect.
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ HASH.clear
 A multi-producer, multi-consumer queue.
 
 ```ruby
-q = Ratomic::Queue.new(128) 
+q = Ratomic::Queue.new(128) # capacity must be a power of 2 and at least 2
 
 q.push("hello")
 q.push("world")
@@ -91,6 +91,7 @@ item = q.pop # => "hello"
 item = q.pop # => "world"
 q.empty?   # => true
 ```
+The `.new(capacity)` method initializes the queue with a fixed-size buffer. The capacity must be a power of 2 and at least 2, which ensures efficient indexing and wrap-around in the underlying buffer
 
 Since `Ratomic::Queue` is a concurrent queue, the `size`, `empty?`, and `peek` methods provide only a best-effort guess — the values they return might be stale or incorrect.
 

--- a/ext/ratomic/mpmc-queue.h
+++ b/ext/ratomic/mpmc-queue.h
@@ -31,8 +31,15 @@ VALUE rb_mpmc_queue_alloc(VALUE klass) {
 
 VALUE rb_mpmc_queue_initialize(VALUE self, VALUE cap) {
   mpmc_queue_t *queue;
+  
+  Check_Type(cap, T_FIXNUM);
+  long capacity = FIX2LONG(cap);
+  if (capacity < 2 || (capacity & (capacity - 1)) != 0) {
+    rb_raise(rb_eArgError, "capacity must be a power of 2 and at least 2");
+  }
+
   TypedData_Get_Struct(self, mpmc_queue_t, &mpmc_queue_data, queue);
-  mpmc_queue_init(queue, FIX2LONG(cap), Qnil);
+  mpmc_queue_init(queue, capacity, Qnil);
   return Qnil;
 }
 

--- a/ext/ratomic/mpmc-queue.h
+++ b/ext/ratomic/mpmc-queue.h
@@ -31,12 +31,14 @@ VALUE rb_mpmc_queue_alloc(VALUE klass) {
 
 VALUE rb_mpmc_queue_initialize(VALUE self, VALUE cap) {
   mpmc_queue_t *queue;
-  
+
   Check_Type(cap, T_FIXNUM);
   long capacity = FIX2LONG(cap);
-  if (capacity < 2 || (capacity & (capacity - 1)) != 0) {
-    rb_raise(rb_eArgError, "capacity must be a power of 2 and at least 2");
-  }
+
+  if (capacity < 1)
+    rb_raise(rb_eArgError, "capacity must be a positive Integer greater than 0");
+  if (capacity > (1L << 20))
+    rb_raise(rb_eArgError, "capacity too large (max: %lu)", 1L << 20);
 
   TypedData_Get_Struct(self, mpmc_queue_t, &mpmc_queue_data, queue);
   mpmc_queue_init(queue, capacity, Qnil);

--- a/rs/src/mpmc_queue.rs
+++ b/rs/src/mpmc_queue.rs
@@ -39,10 +39,7 @@ impl MpmcQueue {
     }
 
     fn init(&mut self, buffer_size: usize, default: c_ulong) {
-        assert!(buffer_size >= 2);
-        assert_eq!(buffer_size & (buffer_size - 1), 0);
-
-        let mut buffer = Vec::with_capacity(buffer_size);
+        let mut buffer = Vec::with_capacity(buffer_size.next_power_of_two());
         for i in 0..buffer_size {
             buffer.push(QueueElement {
                 sequence: AtomicUsize::new(i),

--- a/test/test_queue.rb
+++ b/test/test_queue.rb
@@ -8,6 +8,28 @@ class TestMpmcQueue < Minitest::Test
     @queue = Ratomic::Queue.new(QUEUE_CAPACITY)
   end
 
+  def test_invalid_queue_capacity
+    assert_raises(TypeError, "should raise for non-integer capacity") do
+      Ratomic::Queue.new("not-an-int")
+    end
+  
+    assert_raises(TypeError, "should raise for float capacity") do
+      Ratomic::Queue.new(8.5)
+    end
+  
+    assert_raises(ArgumentError, "should raise for capacity < 2") do
+      Ratomic::Queue.new(1)
+    end
+  
+    assert_raises(ArgumentError, "should raise for capacity that is not a power of 2") do
+      Ratomic::Queue.new(3)
+    end
+  
+    assert_raises(ArgumentError, "should raise for capacity that is not a power of 2") do
+      Ratomic::Queue.new(100)
+    end
+  end
+
   def test_basic_operations
     assert @queue.empty?, "initial queue should be empty"
     assert_equal 0, @queue.size, "initial size should be 0"

--- a/test/test_queue.rb
+++ b/test/test_queue.rb
@@ -8,7 +8,7 @@ class TestMpmcQueue < Minitest::Test
     @queue = Ratomic::Queue.new(QUEUE_CAPACITY)
   end
 
-  def test_invalid_queue_capacity
+  def test_queue_capacity
     assert_raises(TypeError, "should raise for non-integer capacity") do
       Ratomic::Queue.new("not-an-int")
     end
@@ -17,16 +17,16 @@ class TestMpmcQueue < Minitest::Test
       Ratomic::Queue.new(8.5)
     end
   
-    assert_raises(ArgumentError, "should raise for capacity < 2") do
-      Ratomic::Queue.new(1)
+    assert_raises(ArgumentError, "should raise for negative capacity") do
+      Ratomic::Queue.new(-21)
     end
-  
-    assert_raises(ArgumentError, "should raise for capacity that is not a power of 2") do
-      Ratomic::Queue.new(3)
+
+    assert_raises(ArgumentError, "should raise for too large capacity") do
+      Ratomic::Queue.new(2**20+1)
     end
-  
-    assert_raises(ArgumentError, "should raise for capacity that is not a power of 2") do
-      Ratomic::Queue.new(100)
+
+    assert_raises(ArgumentError, "should raise for zero capacity") do
+      Ratomic::Queue.new(0)
     end
   end
 


### PR DESCRIPTION
Currently, the queue initialized with an invalid value will fail a Rust assertion and crash the Ruby app.
This PR validates the capacity before passing it to Rust and raises exceptions for invalid values. It also adds a small snippet in readme to explain the usage of queue capacity param.  