### PR TITLE
Fill out contact method in Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -60,7 +60,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-[INSERT CONTACT METHOD].
+https://github.com/mperham/ratomic/issues/new.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the


### PR DESCRIPTION
## Summary

Fills out the `[INSERT CONTACT METHOD]` placeholder in the Enforcement section of the Code of Conduct, as raised in #9.

## Change

Replaced `[INSERT CONTACT METHOD]` with a link to open a new GitHub issue, which serves as a neutral, always-available contact point that doesn't expose a personal email address.

```diff
diff --git a/CODE_OF_CONDUCT.md b/CODE_OF_CONDUCT.md
index 67fe8ce..ed3b0db 100644
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -60,7 +60,7 @@ representative at an online or offline event.
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-[INSERT CONTACT METHOD].
+https://github.com/mperham/ratomic/issues/new.
 All complaints will be reviewed and investigated promptly and fairly.
 All community leaders are obligated to respect the privacy and security of the
```

> **Note:** If you'd prefer a direct email address instead, happy to update the PR — just let me know what to use.

## Testing

No code changes — documentation only.

Closes #9
