### PR TITLE
Expand CI test matrix to ubuntu + macos with Ruby 3.4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
-
+      
+        # dtolnay/rust-toolchain is maintained by David Tolnay (author of serde, syn, anyhow)
+        # and is the de facto standard for Rust in GitHub Actions, used by rust-lang org itself.
       - name: Set up Rust toolchain
         uses: dtolnay/rust-toolchain@stable
       

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,27 +1,63 @@
-name: Ruby
+name: CI
 
 on:
   push:
     branches:
       - trunk
-
+      - ci/cross-platform-strategy-matrix
   pull_request:
+    branches:
+      - trunk
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    name: Ruby ${{ matrix.ruby }}
+  test:
+    name: Ruby ${{ matrix.ruby }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+
     strategy:
+      fail-fast: false
       matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
         ruby:
-          - '3.4.1'
+          - "3.4"
 
     steps:
-      - uses: actions/checkout@v4
-      - name: Set up Ruby
+      - uses: actions/checkout@v6
+
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      
+      - name: Cache Rust build artifacts
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            ~/.cargo/bin
+            ext/ratomic/target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Install cbindgen via Cargo
+        run: |
+          if ! command -v cbindgen &> /dev/null; then
+            cargo install cbindgen --force
+          fi
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+
+      - name: Verify installation
+        run: cbindgen --version
+      
+      - run: cd rs && cargo test --all-features
+
+      - name: Set up Ruby ${{ matrix.ruby }}
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
-      - name: Run the default task
+
+      - name: Compile extension and run the default task
         run: bundle exec rake

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - trunk
-      - ci/cross-platform-strategy-matrix
   pull_request:
     branches:
       - trunk


### PR DESCRIPTION
## Summary

Expand CI test matrix to ubuntu + macos with Ruby 3.4



## Description
Extend the CI matrix to test on ubuntu + macos and Ruby 3.4 -- and leave the full cross-compilation (rake-compiler-dock) pipeline as a follow-up to issue https://github.com/mperham/ratomic/issues/3.

Note: depends on #17 -- that has to be merged  first to restore macOS green.
