### PR TITLE
fix: macOS semaphore and GVL wrapper corrections

### DIFF
--- a/ext/ratomic/mpmc-queue.h
+++ b/ext/ratomic/mpmc-queue.h
@@ -78,10 +78,24 @@ VALUE rb_mpmc_queue_peek(VALUE self) {
   return item;
 }
 
+
+// Add wrapper to these functions: `mpmc_queue_is_empty` and `mpmc_queue_size`
+static void *mpmc_queue_is_empty_gvl_wrapper(void *data) {
+  // Cast the boolean result to a void* size integer
+  return (void *)(uintptr_t)mpmc_queue_is_empty(data);
+}
+
+static void *mpmc_queue_size_gvl_wrapper(void *data) {
+  // Cast the size_t/uintptr_t result to a void*
+  return (void *)(uintptr_t)mpmc_queue_size(data);
+}
+
 VALUE rb_mpmc_queue_is_empty(VALUE self) {
   mpmc_queue_t *queue;
   TypedData_Get_Struct(self, mpmc_queue_t, &mpmc_queue_data, queue);
-  void *ptr = rb_thread_call_without_gvl(mpmc_queue_is_empty, queue, NULL, NULL);
+
+  void *ptr = rb_thread_call_without_gvl(mpmc_queue_is_empty_gvl_wrapper, queue, NULL, NULL);
+  
   VALUE is_empty = (VALUE)ptr;
   return is_empty ? Qtrue : Qfalse;
 }
@@ -89,7 +103,9 @@ VALUE rb_mpmc_queue_is_empty(VALUE self) {
 VALUE rb_mpmc_queue_size(VALUE self) {
   mpmc_queue_t *queue;
   TypedData_Get_Struct(self, mpmc_queue_t, &mpmc_queue_data, queue);
-  void *ptr = rb_thread_call_without_gvl(mpmc_queue_size, queue, NULL, NULL);
+
+  void *ptr = rb_thread_call_without_gvl(mpmc_queue_size_gvl_wrapper, queue, NULL, NULL);
+
   size_t size = (size_t)ptr;
   return LONG2NUM(size);
 }

--- a/rs/src/sem.rs
+++ b/rs/src/sem.rs
@@ -1,72 +1,69 @@
-use std::time::Duration;
-
-use libc::{
-    CLOCK_REALTIME, clock_gettime, sem_destroy, sem_init, sem_post, sem_t, sem_wait,
-};
+use std::sync::{Condvar, Mutex};
 
 pub(crate) struct Semaphore {
-    inner: *mut sem_t,
+    // Wrap the state in a heap-allocated Box so the raw pointer `self.inner` remains stable
+    inner: *mut SemaphoreInner,
+}
+
+struct SemaphoreInner {
+    lock: Mutex<u32>, // the current count of permits
+    cvar: Condvar,
 }
 
 impl Semaphore {
     pub(crate) fn alloc() -> Self {
-        unsafe { std::mem::zeroed() }
+        Self {
+            inner: std::ptr::null_mut(),
+        }
     }
 
     pub(crate) fn init(&mut self, initial: u32) {
-        let ptr = Box::into_raw(Box::new(unsafe { std::mem::zeroed() }));
-
-        let res = unsafe { sem_init(ptr, 0, initial) };
-        if res != 0 {
-            panic!(
-                "failed to create semaphore: {:?}",
-                std::io::Error::last_os_error()
-            )
-        }
-
-        self.inner = ptr;
+        let inner_struct = SemaphoreInner {
+            lock: Mutex::new(initial),
+            cvar: Condvar::new(),
+        };
+        // Box into raw pointer to manage memory life manually
+        self.inner = Box::into_raw(Box::new(inner_struct));
     }
 
     pub(crate) fn post(&self) {
-        let res = unsafe { sem_post(self.inner) };
-        if res != 0 {
-            panic!(
-                "failed to post to semaphore: {:?}",
-                std::io::Error::last_os_error()
-            )
+        if self.inner.is_null() {
+            return;
         }
+        
+        let inner = unsafe { &*self.inner };
+        let mut count = inner.lock.lock().unwrap();
+        *count += 1;
+        
+        // notify to wake up a waiting thread
+        inner.cvar.notify_one();
     }
 
     pub(crate) fn wait(&self) {
-        let res = unsafe { sem_wait(self.inner) };
-        if res != 0 {
-            panic!(
-                "failed to wait for semaphore: {:?}",
-                std::io::Error::last_os_error()
-            )
+        if self.inner.is_null() {
+            return;
         }
-    }
 
-    // pub(crate) fn wait_for(&self, duration: Duration) -> bool {
-    //     let mut abstime = unsafe { std::mem::zeroed() };
-    //     let res = unsafe { clock_gettime(CLOCK_REALTIME, &mut abstime) };
-    //     if res != 0 {
-    //         panic!(
-    //             "failed to call clock_gettime: {:?}",
-    //             std::io::Error::last_os_error()
-    //         );
-    //     }
-    //     abstime.tv_nsec += duration.as_nanos() as i64;
-    //     let res = unsafe { sem_timedwait(self.inner, &abstime) };
-    //     res != -1
-    // }
+        let inner = unsafe { &*self.inner };
+        let mut count = inner.lock.lock().unwrap();
+        
+        // Block the thread while there are no available permits
+        while *count == 0 {
+            count = inner.cvar.wait(count).unwrap();
+        }
+        
+        *count -= 1;
+    }
 }
 
 impl Drop for Semaphore {
     fn drop(&mut self) {
-        unsafe {
-            sem_destroy(self.inner);
-            drop(Box::from_raw(self.inner));
+        if !self.inner.is_null() {
+            unsafe {
+                // Safely reclaim and drop the heap allocated struct
+                let _ = Box::from_raw(self.inner);
+            }
+            self.inner = std::ptr::null_mut();
         }
     }
 }


### PR DESCRIPTION
## Summary
Fix macOS build failures in `sem.rs` and `mpmc-queue.h` surfaced by cross-platform CI.

## Description
These fixes were discovered when running CI on macOS as part of #16.

---

### `fix(rs)`: swap POSIX semaphores for `std::sync` to fix macOS test panic
macOS deprecated unnamed POSIX semaphores (`sem_init`) -- they compile but panic at runtime.
Replaced the implementation with `std::sync::{Mutex, Condvar}` which is portable and safe across both Linux and macOS.

### `fix(c)`: add GVL wrapper to `mpmc_queue_is_empty` and `mpmc_queue_size`
`rb_thread_call_without_gvl` requires a function pointer with the signature `void* fn(void*)`. Passing `mpmc_queue_is_empty` and `mpmc_queue_size` directly was undefined behaviour due to signature mismatch. Added proper `_gvl_wrapper` functions to bridge the types correctly.

NOTE: These fixes are required for PR #16 to pass on macOS.
