### PR TITLE
dx: add Docker-based local test environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 *.bundle
 rs/target
 lib/ratomic/ratomic.so
+Gemfile.lock

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,0 +1,6 @@
+[tools]
+ruby = "3.4"
+rust = "stable"
+
+[tasks.bindgen]
+run = "cargo install cbindgen"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,41 @@
+# syntax=docker/dockerfile:1
+
+# -----------------------------------------------------------------------------
+# ratomic local development image
+# Installs Rust + Ruby and compiles the native extension for Linux testing.
+# macOS contributors test natively; this image covers the Linux platform.
+# -----------------------------------------------------------------------------
+
+ARG RUBY_VERSION=3.4
+FROM ruby:${RUBY_VERSION}-slim
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    curl \
+    git \
+    libclang-dev \
+    pkg-config \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Rust via rustup (non-interactive, stable toolchain)
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+    | sh -s -- -y --default-toolchain stable --profile minimal
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+WORKDIR /app
+
+RUN cargo install cbindgen
+
+# Cache gems separately from source so bundle install
+# only re-runs when Gemfile/gemspec changes
+COPY Gemfile* *.gemspec ./
+COPY lib/ratomic/version.rb lib/ratomic/version.rb
+RUN bundle install
+
+# Copy the rest of the source
+COPY . .
+
+# Default: compile the extension and run the full test suite
+CMD ["bundle", "exec", "rake"]
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,56 @@
+# -----------------------------------------------------------------------------
+# ratomic local developer experience
+#
+# Simulates the CI matrix locally on Linux across Ruby versions.
+# If macOS is your host machine — run `bundle exec rake` natively there.
+#
+# Usage:
+#   Run all Ruby versions in parallel:
+#     docker compose up --build
+#
+#   Run a specific Ruby version:
+#     docker compose run --build ruby34
+#
+#   Run and exit with the test result code (for scripting dx):
+#     docker compose run ruby34
+#
+#   Tear down:
+#     docker compose down
+# -----------------------------------------------------------------------------
+
+services:
+
+  # ruby 3.4 — current stable (status quo)
+  ruby34:
+    build:
+      context: .
+      args:
+        RUBY_VERSION: "3.4"
+    image: ratomic-test:ruby34
+    volumes:
+      # mount source so edits reflect without rebuild
+      # extension must still be recompiled via rake
+      - .:/app
+      - cargo-cache:/root/.cargo/registry
+      - target-cache:/rs/target
+    command: bundle exec rake
+
+  # --------------------------------------------------------------------------------#
+  # Future versions — uncomment when ready (and most probably delete lines 23-37)   #
+  # ---------------------------------------------------------------------------------#
+  # Ruby 4.0 — target after Ractor API migration (issue #3 roadmap Phase 1)
+  # ruby40:
+  #   build:
+  #     context: .
+  #     args:
+  #       RUBY_VERSION: "4.0"
+  #   image: ratomic-test:ruby40
+  #   volumes:
+  #     - .:/app
+  #     - cargo-cache:/root/.cargo/registry
+  #     - target-cache:/app/ext/ratomic/target
+  #   command: bundle exec rake
+
+volumes:
+  cargo-cache:
+  target-cache:

--- a/rs/rust-atomics.h
+++ b/rs/rust-atomics.h
@@ -45,7 +45,7 @@ void concurrent_hash_map_drop(concurrent_hash_map_t *hashmap);
 
 void concurrent_hash_map_clear(const concurrent_hash_map_t *hashmap);
 
-size_t concurrent_hash_map_size(const concurrent_hash_map_t *hashmap);
+uintptr_t concurrent_hash_map_size(const concurrent_hash_map_t *hashmap);
 
 unsigned long concurrent_hash_map_get(const concurrent_hash_map_t *hashmap,
                                       unsigned long key,
@@ -90,8 +90,8 @@ void *mpmc_queue_pop(void *q);
 
 void *mpmc_queue_peek(void *q);
 
-void *mpmc_queue_is_empty(void *q);
+bool mpmc_queue_is_empty(void *q);
 
-void *mpmc_queue_size(void *q);
+uintptr_t mpmc_queue_size(void *q);
 
 #endif  /* RUST_ATOMICS_H */


### PR DESCRIPTION
## Summary
Add Docker-based local test environment for Linux platform testing.

## Description
Contributors on any OS can now validate the full test suite on Linux
locally without pushing to CI.

- `Dockerfile`  -- Ruby 3.4 slim + Rust stable + cbindgen, mirrors the CI environment
- `docker-compose.yml`  -- single service, named volumes for Cargo cache
- `.mise.toml`  --  pins Ruby 3.4 and Rust stable for contributors using mise
-  `Gemfile.lock` added to `.gitignore` per gem conventions 
  (ref: https://yehudakatz.com/2010/12/16/clarifying-the-roles-of-the-gemspec-and-gemfile/
  by Yehuda Katz -- "the long lost distant cousin of Matz" 😄)
- Regenerated `rs/rust-atomics.h` with correct type signatures via cbindgen

### Usage
```bash
# Full test suite on Linux
docker compose run ruby34
```

