### PR TITLE
perf: reduce ratomic.so size by ~50% (2.5MB  -> 1.3MB)

### DIFF
--- a/ext/ratomic/extconf.rb
+++ b/ext/ratomic/extconf.rb
@@ -7,6 +7,9 @@ require "mkmf"
 # selectively, or entirely remove this flag.
 append_cflags("-fvisibility=hidden")
 
+# Strip debug symbols from the final .so in release builds
+append_ldflags("-Wl,--strip-all") unless ENV["DEBUG"]
+
 rust_atomics_path = File.expand_path("../../../rs", __FILE__)
 # rubocop:disable Style/GlobalVars
 $INCFLAGS << " -I#{rust_atomics_path}"

--- a/rs/Cargo.toml
+++ b/rs/Cargo.toml
@@ -16,9 +16,20 @@ parking_lot = "0.12.3"
 libc = "0.2.170"
 
 [profile.release]
-panic = "abort"
-lto = true
-codegen-units = 1
+panic = "abort"     # abort on panic instead of unwinding — smaller binary, no unwinding tables
+lto = true          # link-time optimization — strips dead code across crates
+codegen-units = 1   # single codegen unit — better optimization, slower compile
+
+# Added these here just in case one might want to do some benchmarking in the future with these different options
+# opt-level = "z"     # optimize for size, not speed
+# options are:
+# 0  — no optimization (fastest compile, biggest/slowest binary) — default for debug
+# 1  — basic optimization
+# 2  — moderate optimization  
+# 3  — aggressive optimization (fastest binary) — default for release
+# s  — optimize for size (moderate)
+# z  — optimize for size (aggressive) — "z" as in "minimize to zero"
+
 
 [[bin]]
 bench = false


### PR DESCRIPTION
## Summary
Reduce installed binary size by ~50% via a single linker flag in `extconf.rb`.

## Description
Debug symbols were leaking into the final `ratomic.so` at the C linker
stage  -- not the Rust stage. Adding `-Wl,--strip-all` to the linker flags
strips them at the right point in the build pipeline.

**Before:** 2.5MB
**After:** 1.3MB

`DEBUG=1` environment variable preserves symbols for development:
```bash
DEBUG=1 bundle exec rake compile
```

Closes #2.