### PR TITLE
Feat: The "inception pool" aka Ratomic::LocalPool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 ## [Unreleased]
 
+## [0.4.0] - 2026-06-10
+
+### Added
+
+* Introduced `Ratomic::LocalPool`, a new pooling primitive for live resources that should remain local to the Ractor that created them.
+* Added Redis-based smoke tests demonstrating safe operation across both Threads and Ractors.
+* Added queue producer/consumer Redis examples.
+* Added RBS definitions for `LocalPool`.
+* Expanded API documentation and usage examples.
+
+### Design
+
+`Ratomic::Pool` and `Ratomic::LocalPool` serve different ownership models:
+
+* `Pool` — ownership transfer
+* `LocalPool` — ownership preservation
+
+`LocalPool` is intended for resources such as:
+
+* Redis clients
+* Database connections
+* HTTP clients
+* Kafka producers
+* Other stateful network resources
+
+### Notes
+
+`LocalPool` is implemented in pure Ruby and is not backed by Ratomic's Rust extension.
+
+
 ## [0.3.5] - 2026-06-06
 
 - Fix the native loader so development loads the compiled extension from the

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,14 @@
 members = ["ext/ratomic"]
 resolver = "2"
 
+[profile.dev]
+debug = true
+
 [profile.release]
 panic = "abort"
 lto = true
 codegen-units = 1
+# By default, debug symbols are stripped from the final binary which makes it
+# harder to debug if something goes wrong. It's recommended to keep debug
+# symbols in the release build so that you can debug the final binary if needed.
+debug = false

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Ruby Version](https://img.shields.io/badge/ruby-%3E%3D%204.0-ruby.svg)](https://www.ruby-lang.org/en/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-Ratomic provides mutable data structures for Ruby Ractors. Its primitives are backed by native Rust concurrency libraries so Ruby code can share useful state across Ractors without falling back to one global lock. `Pool` uses Ruby Ractor ownership-transfer primitives instead of the native Rust path.
+Ratomic provides mutable data structures for Ruby Ractors. Its core shared primitives are backed by native Rust concurrency libraries so Ruby code can share useful state across Ractors without falling back to one global lock. `Pool` and `LocalPool` are pure Ruby primitives that use Ruby Ractor ownership and locality semantics instead of the native Rust path.
 
 ## Project Direction
 
@@ -43,7 +43,7 @@ RBS signatures are included under `sig/` for downstream type checking.
 ## Examples And Benchmarks
 
 - [`redis_poc`](./redis_poc) contains local Redis scripts that exercise
-  `Ratomic::Map`, `Ratomic::Counter`, and `Ratomic::Pool` under Thread and
+  `Ratomic::Map`, `Ratomic::Counter`, and `Ratomic::LocalPool` under Thread and
   Ractor workloads.
 - [`pgoutput-parser`](https://github.com/kanutocd/pgoutput-parser#relation-metadata-tracking)
   uses `Ratomic::Map` for relation metadata tracking in a real CDC pipeline
@@ -59,10 +59,11 @@ RBS signatures are included under `sig/` for downstream type checking.
 
 ## Usage
 
-Ratomic provides two safety models:
+Ratomic provides three safety models:
 
 - `Counter`, `Map`, and `Queue` are shared concurrent structures.
-- `Pool` transfers ownership of mutable objects between Ractors.
+- `Pool` transfers ownership of plain mutable objects between Ractors.
+- `LocalPool` keeps live resources local to the Ractor that created them.
 
 That distinction matters. A mutable pooled object is not shared by multiple Ractors
 at the same time. It is moved to the caller on checkout and moved back to the pool
@@ -126,6 +127,11 @@ groups = Ratomic::Map.new
 groups.append("jobs", "import") # => ["import"]
 groups.add_to_set("workers", "alpha") # => #<Set: {"alpha"}>
 ```
+
+Some `Map` methods hold an internal guard while a block runs or while a
+reference is live. Avoid re-entering the same map from inside those blocks or
+mutating the same key while holding a reference from `get` or `[]`. The API
+docs cover the exact locking caveats.
 
 ### `Ratomic::Queue`
 
@@ -226,6 +232,142 @@ process crash.
 The lower-level `Ratomic::FixedSizeObjectPool` native class may still exist, but
 `Ratomic::Pool` does not inherit from it. The public `Pool` API is implemented
 in Ruby so it can use Ruby's Ractor ownership primitives directly.
+
+
+### `Ratomic::LocalPool`
+
+`Ratomic::LocalPool` is the safe pool shape for live resources that should stay
+local to the Ractor that created them.
+
+Use it for resources such as:
+
+- Redis clients
+- database connections
+- HTTP clients
+- Kafka producers
+- OpenSearch clients
+- per-worker caches, buffers, encoders, or aggregators
+
+Unlike `Ratomic::Pool`, `LocalPool` does **not** move pooled objects between
+Ractors. The `LocalPool` instance is a shareable facade. Each Ractor lazily
+creates and owns its own private, thread-safe resource pool behind that facade.
+Threads inside the same Ractor share that local pool, but different Ractors
+never share the live resources.
+
+```ruby
+require "ratomic"
+require "redis-client"
+
+RedisFactory = Data.define(:host) do
+  def call
+    RedisClient.new(host: host)
+  end
+end
+
+REDIS = Ratomic::LocalPool.new(
+  size: 10,
+  timeout: 1,
+  factory: RedisFactory.new("127.0.0.1".freeze)
+)
+
+REDIS.with do |client|
+  client.call("ping")
+end
+```
+
+Use `Pool` for plain mutable values where ownership transfer is the intended
+safety model. Use `LocalPool` for live resources that should be created, used,
+and reused inside the same Ractor.
+
+The intended topology is:
+
+```text
+shareable LocalPool facade
+        ↓
+one local resource pool per Ractor
+        ↓
+threads inside that Ractor share local resources
+```
+
+The mental model is intentionally close to a Ruby local variable: the resource is
+local to the execution scope that owns it. For `LocalPool`, that scope is the
+current Ractor.
+
+#### Pure Ruby implementation
+
+`LocalPool` is implemented in pure Ruby.
+
+Unlike `Counter`, `Map`, and `Queue`, it is not backed by the Rust native
+extension. Its safety comes from Ruby Ractor ownership boundaries and locality,
+not from Rust synchronization primitives.
+
+#### Why not use `Pool` for Redis clients?
+
+`Pool` moves checked-out objects between Ractors. That is correct for plain
+mutable Ruby values such as arrays or buffers, but it is a poor fit for live I/O
+resources. Redis clients, database connections, sockets, and similar resources
+carry internal connection state. Moving those objects across Ractor boundaries can
+leave nested internal state unusable, producing errors such as
+`Ractor::MovedError`.
+
+`LocalPool` avoids that class of bug by not moving live resources at all. Work
+moves between Ractors. Live resources stay local.
+
+#### Redis smoke-test snapshot
+
+The Redis POC includes two scripts under `redis_poc/`.
+
+`basic_redis.rb` exercises repeated Redis operations from both Threads and
+Ractors:
+
+```text
+Thread
+[{"one" => 31501}, {"two" => 31379}, {"three" => 31320}, {"four" => 31410}, {"five" => 31454}]
+
+Ractor
+[{"one" => 42419}, {"two" => 42186}, {"three" => 42400}, {"four" => 42206}, {"five" => 42568}]
+```
+
+`queue_redis.rb` exercises a producer/consumer Redis queue workload:
+
+```text
+[:start, Ractor, 2026-06-10 01:17:57.584727984 +0800]
+[[:producer_done, 0], [:producer_done, 1]]
+[[:consumer_done, 0, 7998], [:consumer_done, 1, 7987], [:consumer_done, 2, 7984], [:consumer_done, 3, 8035], [:consumer_done, 4, 7996]]
+[{"one" => 0}, {"two" => 0}, {"three" => 0}, {"four" => 0}, {"five" => 0}]
+[:end, 2026-06-10 01:18:02.226310862 +0800]
+```
+
+These numbers are a smoke-test snapshot, not a formal benchmark claim. The
+important interpretation is:
+
+- no `Ractor::MovedError`
+- no `Ractor::IsolationError`
+- no process crash
+- all produced queue items were consumed
+- Redis queues drained to zero
+- live Redis clients remained owned by the Ractor that created them
+
+#### Inception pool
+
+Internally, `LocalPool` follows the "inception pool" shape discovered while
+experimenting with Redis clients under Ruby Ractors:
+
+```text
+pool facade
+  ↓
+local pool
+  ↓
+resource
+```
+
+That same ownership pattern appears in hybrid execution runtimes: put parallel
+workers on the outside, keep I/O concurrency and live resources inside the worker
+that owns them. Ratomic keeps the primitive general-purpose and independent of
+any specific runtime, scheduler, database, or message system.
+
+`LocalPool#close` closes only the current Ractor's local pool. Other Ractors own
+their own pools and must close them independently when needed.
 
 ## Contributing
 

--- a/lib/ratomic.rb
+++ b/lib/ratomic.rb
@@ -4,10 +4,11 @@ require "rbconfig"
 
 # Ratomic provides mutable data structures for Ruby Ractors. Its primitives
 # are backed by native Rust concurrency libraries so Ruby code can share useful
-# state across Ractors without falling back to one global lock. Pool uses Ruby
-# Ractor ownership-transfer primitives instead of the native Rust path.
+# state across Ractors without falling back to one global lock. `Pool` and
+# `LocalPool` are pure Ruby primitives which use Ruby Ractor ownership and
+# locality semantics instead of the native Rust path.
 #
-# The public API currently includes {Counter}, {Map}, {Queue}, and {Pool}.
+# The public API currently includes {Counter}, {Map}, {Queue}, {Pool}, and {LocalPool}.
 module Ratomic
   # Base error class for Ratomic-specific failures.
   class Error < StandardError; end
@@ -53,3 +54,5 @@ require "ratomic/counter"
 require "ratomic/map"
 require "ratomic/queue"
 require "ratomic/pool"
+
+require "ratomic/local_pool"

--- a/lib/ratomic/local_pool.rb
+++ b/lib/ratomic/local_pool.rb
@@ -1,0 +1,246 @@
+# frozen_string_literal: true
+
+require "timeout"
+
+module Ratomic
+  # Design Note
+  #
+  # LocalPool originated while investigating Redis clients under Ruby
+  # Ractors. The original goal was to reuse Pool, but ownership-transfer
+  # semantics proved incompatible with live resources containing internal
+  # state.
+  #
+  # The resulting architecture became known as the "Inception Pool"
+  # design:
+  #
+  #   LocalPool facade
+  #          ↓
+  #   Ractor-local pool
+  #          ↓
+  #   Live resources
+  #
+  # or informally:
+  #
+  #   Pool
+  #     ↓
+  #   Pool
+  #     ↓
+  #   Resource
+  #
+  # The public API intentionally uses the more descriptive name `LocalPool`.
+  #
+  # A shareable facade over resources that stay local to each Ractor.
+  #
+  # LocalPool is intended for live resources such as Redis clients,
+  # database connections, sockets, and other objects which must not be moved
+  # between Ractors. The facade itself is shareable, but each Ractor lazily
+  # creates and owns an independent thread-safe local pool. Threads inside the
+  # same Ractor share that local pool; different Ractors never share the live
+  # resources.
+  #
+  # This is the correct shape for resources with process, socket, connection,
+  # or native state. Move work across Ractor boundaries, not live clients.
+  #
+  # The factory must be Ractor-shareable because the facade stores it and each
+  # Ractor calls it when its local resource pool needs to create a resource. Prefer a
+  # small immutable callable object instead of a block when the pool will be
+  # used from multiple Ractors.
+  #
+  # @example Redis clients owned by each Ractor
+  #   RedisFactory = Data.define(:host) do
+  #     def call
+  #       RedisClient.new(host: host)
+  #     end
+  #   end
+  #
+  #   REDIS = Ratomic::LocalPool.new(
+  #     size: 5,
+  #     timeout: 1,
+  #     factory: RedisFactory.new("127.0.0.1".freeze)
+  #   )
+  #
+  #   REDIS.with { |client| client.call("ping") }
+  #
+  # @note LocalPool is implemented in pure Ruby. It is not backed by the Rust
+  #   native extension used by Counter, Map, and Queue. Its safety comes from
+  #   Ruby Ractor locality: live resources are created and reused inside the
+  #   Ractor that owns them.
+  #
+  # @see Pool Use Pool for plain mutable Ruby values where ownership transfer
+  #   is the desired safety model.
+  class LocalPool
+    # Create a per-Ractor local pool facade.
+    #
+    # @param size [Integer] maximum number of resources in each Ractor-local pool
+    # @param timeout [Numeric, nil] checkout timeout in seconds, or nil to wait indefinitely
+    # @param factory [#call, nil] shareable object factory
+    # @yieldreturn [Object] resource created inside the current Ractor
+    # @raise [ArgumentError] if size, timeout, or factory is invalid
+    # @raise [LocalJumpError] if no factory or block is given
+    def initialize(size: 5, timeout: 1.0, factory: nil, &block)
+      raise ArgumentError, "pool size must be positive" unless size.is_a?(Integer) && size.positive?
+      raise ArgumentError, "pool timeout must be numeric or nil" unless timeout.nil? || timeout.is_a?(Numeric)
+      raise ArgumentError, "pool timeout must be non-negative" if timeout && timeout.negative?
+      raise ArgumentError, "use either factory: or block, not both" if factory && block
+
+      factory ||= block
+      raise LocalJumpError, "no factory given" unless factory
+      raise ArgumentError, "factory must respond to #call" unless factory.respond_to?(:call)
+      raise ArgumentError, "factory must be Ractor-shareable" unless Ractor.shareable?(factory)
+
+      @size = size
+      @timeout = timeout&.to_f
+      @factory = factory
+      @storage_key = :"ratomic_local_pool_#{object_id}"
+
+      freeze
+      Ractor.make_shareable(self)
+    end
+
+    # Checkout a current-Ractor-owned resource, yield it, then return it to the
+    # same Ractor-local pool.
+    #
+    # No resource is moved between Ractors. The yielded object belongs to the
+    # Ractor which called this method.
+    #
+    # @yieldparam object [Object] current-Ractor-owned resource
+    # @raise [Ratomic::Error] if checkout times out
+    # @return [Object] the block return value
+    def with
+      local_pool.with { |object| yield object }
+    rescue Timeout::Error
+      raise Ratomic::Error, "pool checkout timeout"
+    end
+
+    # Close the current Ractor's local pool, if it has been initialized.
+    #
+    # Other Ractors own independent local pools and are not affected. Available
+    # resources are closed if they respond to #close. Resources currently
+    # checked out by threads in this Ractor are closed when returned.
+    #
+    # @return [nil]
+    def close
+      pool = Ractor.current[@storage_key]
+      return nil unless pool
+
+      Ractor.current[@storage_key] = nil
+      pool.close
+      nil
+    end
+
+    # Minimal thread-safe resource pool used inside exactly one Ractor.
+    class ResourcePool
+      def initialize(size:, timeout:, factory:)
+        @size = size
+        @timeout = timeout
+        @factory = factory
+        @available = []
+        @created = 0
+        @closed = false
+        @mutex = Mutex.new
+        @condition = ConditionVariable.new
+      end
+
+      def with
+        object = checkout
+        yield object
+      ensure
+        checkin(object) if object
+      end
+
+      def close
+        objects = nil
+
+        @mutex.synchronize do
+          @closed = true
+          objects = @available.dup
+          @available.clear
+          @condition.broadcast
+        end
+
+        objects.each { |object| close_object(object) }
+        nil
+      end
+
+      private
+
+      def checkout
+        deadline = monotonic_deadline
+
+        should_create = @mutex.synchronize do
+          raise IOError, "pool is closed" if @closed
+
+          loop do
+            object = @available.pop
+            return object if object
+
+            if @created < @size
+              @created += 1
+              break true
+            end
+
+            wait_for_available(deadline)
+            raise IOError, "pool is closed" if @closed
+          end
+        end
+
+        create_object if should_create
+      end
+
+      def checkin(object)
+        close_now = false
+
+        @mutex.synchronize do
+          if @closed
+            close_now = true
+          else
+            @available << object
+            @condition.signal
+          end
+        end
+
+        close_object(object) if close_now
+        nil
+      end
+
+      def create_object
+        @factory.call
+      rescue Exception # rubocop:disable Lint/RescueException
+        @mutex.synchronize do
+          @created -= 1
+          @condition.signal
+        end
+        raise
+      end
+
+      def close_object(object)
+        object.close if object.respond_to?(:close)
+      end
+
+      def monotonic_deadline
+        return nil unless @timeout
+
+        Process.clock_gettime(Process::CLOCK_MONOTONIC) + @timeout
+      end
+
+      def wait_for_available(deadline)
+        if deadline
+          remaining = deadline - Process.clock_gettime(Process::CLOCK_MONOTONIC)
+          raise Timeout::Error, "pool checkout timeout" if remaining <= 0
+
+          @condition.wait(@mutex, remaining)
+        else
+          @condition.wait(@mutex)
+        end
+      end
+    end
+
+    private
+
+    def local_pool
+      Ractor.current[@storage_key] ||= ResourcePool.new(size: @size, timeout: @timeout, factory: @factory)
+    end
+
+    private_constant :ResourcePool
+  end
+end

--- a/lib/ratomic/map.rb
+++ b/lib/ratomic/map.rb
@@ -11,6 +11,11 @@ module Ratomic
   # This is not a full Hash replacement. Iteration and arbitrary mutable object
   # borrowing are intentionally absent.
   #
+  # Some methods on this type hold an internal entry guard while the block runs
+  # or while a reference is live. Do not call back into the same map from inside
+  # those blocks, and do not hold a reference from #get or #[] while mutating
+  # the same key. That can deadlock the underlying DashMap bucket.
+  #
   # @example Store pipeline offsets
   #   OFFSETS = Ratomic::Map.new
   #   OFFSETS[:source_a] = 42
@@ -21,6 +26,10 @@ module Ratomic
   #
   #   Missing keys return nil, so use #key? or #fetch when stored nil values
   #   need to be distinguished from missing entries.
+  #
+  #   If you keep the returned reference alive and then mutate the same key, you
+  #   can deadlock the underlying DashMap bucket. Copy out what you need and let
+  #   the reference go out of scope before mutating.
   #
   #   @param key [Object] lookup key
   #   @return [Object, nil] the stored value, or nil when the key is missing
@@ -102,6 +111,10 @@ module Ratomic
   #   into the same map from inside the block. Prefer native update helpers such
   #   as #increment when they fit the workflow.
   #
+  #   Never call this method from inside another live reference to the same
+  #   entry or from a block that already holds the same map's guard. That can
+  #   deadlock the bucket.
+  #
   #   If the block raises, the previous value is preserved. If the key was
   #   missing, no entry is inserted.
   #
@@ -140,6 +153,10 @@ module Ratomic
   #   locked, so avoid using this method for Ractor-hot loops or calling back
   #   into the same map from inside the block. Prefer native update helpers such
   #   as #increment when they fit the workflow.
+  #
+  #   Never call this method from inside another live reference to the same
+  #   entry or from a block that already holds the same map's guard. That can
+  #   deadlock the bucket.
   #
   #   If the block raises, the previous value is preserved.
   #

--- a/lib/ratomic/version.rb
+++ b/lib/ratomic/version.rb
@@ -2,5 +2,5 @@
 
 module Ratomic
   # Current gem version string.
-  VERSION = "0.3.5"
+  VERSION = "0.4.0"
 end

--- a/redis_poc/Gemfile
+++ b/redis_poc/Gemfile
@@ -3,6 +3,6 @@
 source "https://rubygems.org"
 
 gem "redis-client"
-gem "ratomic", path: ".."
-
 gem "json"
+
+gem "ratomic", path: "../"

--- a/redis_poc/README.md
+++ b/redis_poc/README.md
@@ -1,7 +1,11 @@
 # Redis POC
 
 Small local scripts that exercise `Ratomic::Map`, `Ratomic::Counter`, and
-`Ratomic::Pool` with Redis clients under Thread and Ractor workloads.
+`Ratomic::LocalPool` with Redis clients under Thread and Ractor workloads.
+
+`LocalPool` is used instead of `Ratomic::Pool` because Redis clients are
+live I/O resources. They should be created and reused inside the Ractor that
+owns them, not moved between Ractors.
 
 Start Redis from the repo root:
 
@@ -16,11 +20,23 @@ cd redis_poc
 bundle install
 ```
 
-Run the scripts:
+Run the basic movement script:
 
 ```sh
 bundle exec ruby basic_redis.rb
-bundle exec ruby queue_redis.rb
+```
+
+Run the producer/consumer queue script with Threads or Ractors:
+
+```sh
+TYPE=Thread bundle exec ruby queue_redis.rb
+TYPE=Ractor bundle exec ruby queue_redis.rb
+```
+
+Useful knobs:
+
+```sh
+TIMES=50000 PRODUCERS=4 CONSUMERS=8 POOL_SIZE=8 TYPE=Ractor bundle exec ruby queue_redis.rb
 ```
 
 Use a different Redis host with:
@@ -28,3 +44,53 @@ Use a different Redis host with:
 ```sh
 REDIS_HOST=redis.example.test bundle exec ruby basic_redis.rb
 ```
+
+
+## Smoke-test snapshot
+
+These scripts are demonstrations and smoke tests, not formal benchmarks. They
+exist to show that live Redis clients remain local to the Ractor that created
+them.
+
+A successful `basic_redis.rb` run looked like this:
+
+```text
+Thread
+[{"one" => 31501}, {"two" => 31379}, {"three" => 31320}, {"four" => 31410}, {"five" => 31454}]
+
+Ractor
+[{"one" => 42419}, {"two" => 42186}, {"three" => 42400}, {"four" => 42206}, {"five" => 42568}]
+```
+
+A successful `queue_redis.rb` Ractor run looked like this:
+
+```text
+[:start, Ractor, 2026-06-10 01:17:57.584727984 +0800]
+[[:producer_done, 0], [:producer_done, 1]]
+[[:consumer_done, 0, 7998], [:consumer_done, 1, 7987], [:consumer_done, 2, 7984], [:consumer_done, 3, 8035], [:consumer_done, 4, 7996]]
+[{"one" => 0}, {"two" => 0}, {"three" => 0}, {"four" => 0}, {"five" => 0}]
+[:end, 2026-06-10 01:18:02.226310862 +0800]
+```
+
+Interpretation:
+
+- no `Ractor::MovedError`
+- no `Ractor::IsolationError`
+- all produced queue items were consumed
+- Redis queues drained to zero
+- the `LocalPool` facade was shared, while Redis clients stayed local
+
+## Inception note
+
+`LocalPool` is intentionally a small "inception pool":
+
+```text
+pool facade
+  ↓
+local pool
+  ↓
+resource
+```
+
+That shape later maps naturally to hybrid runtimes where parallel workers own
+local concurrent resource pools.

--- a/redis_poc/basic_redis.rb
+++ b/redis_poc/basic_redis.rb
@@ -1,45 +1,48 @@
-# Run with `bundle exec ruby app.rb`
-require 'ratomic'
-require 'redis-client'
+# Run with `bundle exec ruby basic_redis.rb`
+require "ratomic"
+require "redis-client"
+
+RedisClientFactory = Data.define(:host) do
+  def call
+    RedisClient.new(host: host)
+  end
+end
 
 REDIS_HOST = Ractor.make_shareable(ENV.fetch("REDIS_HOST", "127.0.0.1").dup.freeze)
-
-queues = %w(one two three four five)
+QUEUES = Ractor.make_shareable(%w[one two three four five].map(&:freeze).freeze)
 COUNTS = Ratomic::Map.new
-POOL = Ratomic::Pool.new(50, 1) { RedisClient.new(host: REDIS_HOST) }
+POOL = Ratomic::LocalPool.new(
+  size: Integer(ENV.fetch("POOL_SIZE", "10")),
+  timeout: Float(ENV.fetch("POOL_TIMEOUT", "1")),
+  factory: RedisClientFactory.new(REDIS_HOST)
+)
 
 def concurrent_value(worker)
   worker.join if worker.respond_to?(:join)
   worker.value
 end
 
-types = [Thread, Ractor]
-types.each do |klass|
-  POOL.with {|c| c.call("flushdb") }
-  POOL.with do |conn|
-    queues.each do |q|
-      COUNTS.set(q, Ratomic::Counter.new)
-      conn.call("lpush", q, "element")
-    end
+[Thread, Ractor].each do |klass|
+  POOL.with { |client| client.call("flushdb") }
+  QUEUES.each do |queue|
+    COUNTS.set(queue, Ratomic::Counter.new)
+    POOL.with { |client| client.call("lpush", queue, "element") }
   end
 
-  ending = Time.now + 10
-  concurrency = []
-  5.times do
-    concurrency << klass.new(queues, ending) do |queues, stop|
+  ending = Time.now + Integer(ENV.fetch("SECONDS", "10"))
+  workers = 5.times.map do
+    klass.new(QUEUES, ending) do |queues, stop|
       loop do
-        q = queues.sample
-        POOL.with do |conn|
-          conn.call("rpoplpush", q, queues.sample)
-          COUNTS.get(q).increment(1)
+        queue = queues.sample
+        POOL.with do |client|
+          client.call("rpoplpush", queue, queues.sample)
+          COUNTS.get(queue).increment(1)
         end
-        # p [Time.now, stop]
         break if Time.now > stop
       end
     end
   end
-  concurrency.map { |worker| concurrent_value(worker) }
-  p(klass, queues.map do |q|
-    { q => COUNTS.get(q).read }
-  end)
+
+  workers.each { |worker| concurrent_value(worker) }
+  p(klass, QUEUES.map { |queue| { queue => COUNTS.get(queue).read } })
 end

--- a/redis_poc/queue_redis.rb
+++ b/redis_poc/queue_redis.rb
@@ -1,80 +1,83 @@
-# Run with `bundle exec ruby app.rb`
-require 'ratomic'
-require 'redis-client'
-# require 'json'
-# require 'securerandom'
+# Run with `TYPE=Thread bundle exec ruby queue_redis.rb`
+# Run with `TYPE=Ractor bundle exec ruby queue_redis.rb`
+require "ratomic"
+require "redis-client"
+
+RedisClientFactory = Data.define(:host, :read_timeout) do
+  def call
+    RedisClient.new(host: host, read_timeout: read_timeout)
+  end
+end
 
 REDIS_HOST = Ractor.make_shareable(ENV.fetch("REDIS_HOST", "127.0.0.1").dup.freeze)
+TIMES = Integer(ENV.fetch("TIMES", "20000"))
+PRODUCERS = Integer(ENV.fetch("PRODUCERS", "2"))
+CONSUMERS = Integer(ENV.fetch("CONSUMERS", "5"))
+STOP = Ractor.make_shareable("__ratomic_stop__".freeze)
 
-times = 20_000
-queues = %w(one two three four five)
+QUEUES = Ractor.make_shareable(%w[one two three four five].map(&:freeze).freeze)
 COUNTS = Ratomic::Map.new
-POOL = Ratomic::Pool.new(50, 1) { RedisClient.new(host: REDIS_HOST, read_timeout: 3) }
+POOL = Ratomic::LocalPool.new(
+  size: Integer(ENV.fetch("POOL_SIZE", "8")),
+  timeout: Float(ENV.fetch("POOL_TIMEOUT", "1")),
+  factory: RedisClientFactory.new(REDIS_HOST, 3)
+)
 
 def concurrent_value(worker)
   worker.join if worker.respond_to?(:join)
   worker.value
 end
 
-POOL.with {|c| c.call("flushdb") }
-POOL.with do |conn|
-  queues.each do |q|
-    COUNTS.set(q, Ratomic::Counter.new)
-  end
-end
+POOL.with { |client| client.call("flushdb") }
+QUEUES.each { |queue| COUNTS.set(queue, Ratomic::Counter.new) }
 
 # TYPE=Thread or TYPE=Ractor bundle exec ruby queue_redis.rb
-conctype = Object.const_get(ENV.fetch("TYPE", "Ractor"))
+concurrency_type = Object.const_get(ENV.fetch("TYPE", "Ractor"))
 
-p [:start, Time.now]
-concurrency = []
-2.times do |off|
-  concurrency << conctype.new(off, queues, times) do |ridx, qs, cnt|
-    p [:client, Time.now]
-    # offset = (ridx * cnt)
-    qsz = qs.size
-    POOL.with {|c|
-      cnt.times do |idx|
-        q = qs[idx % qsz]
-        # jid = SecureRandom.hex(12)
-        c.call("lpush", q, "job")
-          # m.call("sadd", "jids", jid)
-        COUNTS.get(q).increment(1)
-      end
-    }
-    p [:client_done, Time.now]
-  end
-end
+p [:start, concurrency_type, Time.now]
 
-5.times do
-  concurrency << conctype.new(queues) do |q|
-    p [:process, q, Time.now]
-    loop do
-      element = POOL.with do |conn|
-        conn.call("brpop", *q, 2)
-      end
-      p element unless element.nil? || element.size == 2
-      break unless element&.size == 2
-      # COUNTS.get(q).decrement(1)
-      # job = JSON.parse(element[1])
-      # POOL.with {|c| c.call("srem", "jids", job['jid']) }
-      # job
+producers = PRODUCERS.times.map do |producer_index|
+  concurrency_type.new(producer_index, QUEUES, TIMES) do |ridx, queues, count|
+    queue_count = queues.size
+
+    count.times do |idx|
+      queue = queues[(idx + ridx) % queue_count]
+      POOL.with { |client| client.call("lpush", queue, "job") }
+      COUNTS.get(queue).increment(1)
     end
-  ensure
-    p [:process_done, q, Time.now]
+
+    [:producer_done, ridx]
   end
 end
 
-Thread.new do
-  loop do
-    p(queues.map do |q|
-      { q => COUNTS.get(q).read }
-    end)
-    sleep 2
+consumers = CONSUMERS.times.map do |consumer_index|
+  concurrency_type.new(consumer_index, QUEUES, STOP) do |ridx, queues, stop_marker|
+    processed = 0
+
+    loop do
+      item = POOL.with { |client| client.call("brpop", *queues, 2) }
+      next if item.nil?
+
+      queue, payload = item
+      break if payload == stop_marker
+
+      COUNTS.get(queue).decrement(1)
+      processed += 1
+    end
+
+    [:consumer_done, ridx, processed]
   end
 end
 
-concurrency.map { |worker| concurrent_value(worker) }
+producer_results = producers.map { |worker| concurrent_value(worker) }
+
+CONSUMERS.times do
+  POOL.with { |client| client.call("lpush", QUEUES.first, STOP) }
+end
+
+consumer_results = consumers.map { |worker| concurrent_value(worker) }
+
+p producer_results
+p consumer_results
+p(QUEUES.map { |queue| { queue => COUNTS.get(queue).read } })
 p [:end, Time.now]
-
-# p POOL.with {|c| c.call "scard", "jids" }

--- a/sig/ratomic.rbs
+++ b/sig/ratomic.rbs
@@ -62,6 +62,14 @@ module Ratomic
     def length: () -> Integer
   end
 
+  class LocalPool
+    def self.new: (?size: Integer, ?timeout: (Numeric | nil), factory: untyped) -> LocalPool
+                | (?size: Integer, ?timeout: (Numeric | nil)) { () -> untyped } -> LocalPool
+
+    def with: () { (untyped object) -> untyped } -> untyped
+    def close: () -> nil
+  end
+
   class Pool
     def self.new: (?Integer size, ?(Numeric | nil) timeout) { () -> untyped } -> Pool
 

--- a/test/test_local_pool.rb
+++ b/test/test_local_pool.rb
@@ -1,0 +1,173 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TestLocalPool < Minitest::Test
+  class ArrayFactory
+    def call
+      []
+    end
+  end
+
+  class Closable
+    attr_reader :closed
+
+    def initialize
+      @closed = false
+    end
+
+    def close
+      @closed = true
+    end
+  end
+
+  FACTORY = Ractor.make_shareable(ArrayFactory.new.freeze)
+
+  def test_pool_is_shareable
+    pool = Ratomic::LocalPool.new(factory: FACTORY)
+    assert Ractor.shareable?(pool)
+  end
+
+  def test_requires_positive_integer_size
+    assert_raises(ArgumentError) { Ratomic::LocalPool.new(size: 0, factory: FACTORY) }
+    assert_raises(ArgumentError) { Ratomic::LocalPool.new(size: 1.5, factory: FACTORY) }
+  end
+
+  def test_requires_numeric_timeout
+    assert_raises(ArgumentError) do
+      Ratomic::LocalPool.new(timeout: "foo", factory: FACTORY)
+    end
+  end
+
+  def test_requires_non_negative_timeout
+    assert_raises(ArgumentError) do
+      Ratomic::LocalPool.new(size: 1, timeout: -1, factory: FACTORY)
+    end
+  end
+
+  def test_requires_factory
+    assert_raises(LocalJumpError) do
+      Ratomic::LocalPool.new
+    end
+  end
+
+  def test_rejects_factory_and_block
+    assert_raises(ArgumentError) do
+      Ratomic::LocalPool.new(factory: FACTORY) { [] }
+    end
+  end
+
+  def test_rejects_non_callable_factory
+    factory = Ractor.make_shareable(Object.new.freeze)
+
+    assert_raises(ArgumentError) do
+      Ratomic::LocalPool.new(factory: factory)
+    end
+  end
+
+  def test_requires_shareable_factory
+    error = assert_raises(ArgumentError) do
+      Ratomic::LocalPool.new { [] }
+    end
+
+    assert_match(/factory must be Ractor-shareable/, error.message)
+  end
+
+  def test_close_before_initialization_is_noop
+    pool = Ratomic::LocalPool.new(factory: FACTORY)
+    assert_nil pool.close
+  end
+
+  def test_threads_share_current_local_pool
+    pool = Ratomic::LocalPool.new(size: 1, timeout: 0.1, factory: FACTORY)
+    object_ids = Queue.new
+
+    3.times.map do
+      Thread.new do
+        pool.with do |object|
+          object_ids << object.object_id
+        end
+      end
+    end.each(&:join)
+
+    assert_equal 1, 3.times.map { object_ids.pop }.uniq.size
+  ensure
+    pool&.close
+  end
+
+  def test_each_ractor_gets_its_own_local_pool
+    pool = Ratomic::LocalPool.new(size: 1, timeout: 0.1, factory: FACTORY)
+
+    results = 2.times.map do
+      Ractor.new(pool) do |local_pool|
+        first = nil
+        second = nil
+
+        local_pool.with { |object| first = object.object_id }
+        local_pool.with { |object| second = object.object_id }
+
+        local_pool.close
+        [first == second, first]
+      end
+    end.map { |ractor| ractor_value(ractor) }
+
+    assert results.all?(&:first)
+    refute_equal results[0][1], results[1][1]
+  end
+
+  def test_timeout_raises_ratomic_error
+    pool = Ratomic::LocalPool.new(size: 1, timeout: 0.01, factory: FACTORY)
+    error = nil
+
+    pool.with do
+      thread = Thread.new do
+        begin
+          pool.with { |_object| :unreachable }
+        rescue Ratomic::Error => e
+          error = e
+        end
+      end
+      thread.join
+    end
+
+    assert_instance_of Ratomic::Error, error
+    assert_match(/pool checkout timeout/, error.message)
+  ensure
+    pool&.close
+  end
+
+  def test_close_closes_available_resources
+    resource = Closable.new
+
+    factory = Class.new do
+      define_method(:call) { resource }
+    end.new
+
+    Ractor.make_shareable(factory)
+
+    pool = Ratomic::LocalPool.new(factory: factory)
+
+    pool.with { |_obj| nil }
+    pool.close
+
+    assert resource.closed
+  end
+
+  def test_factory_failure_propagates
+    factory = Class.new do
+      def call
+        raise "boom"
+      end
+    end.new
+
+    Ractor.make_shareable(factory)
+
+    pool = Ratomic::LocalPool.new(factory: factory)
+
+    error = assert_raises(RuntimeError) do
+      pool.with { }
+    end
+
+    assert_equal "boom", error.message
+  end
+end


### PR DESCRIPTION
# Summary

This PR introduces `Ratomic::LocalPool`, a new pooling primitive for resources that should remain local to the Ractor that created them.

Examples include:

* Redis clients
* PostgreSQL connections
* HTTP clients
* Kafka producers
* Other stateful resources with internal connection/socket/native state

## Background

While experimenting with Redis clients under Ruby Ractors, the ownership-transfer semantics were exposed that they are not always appropriate for live resources.

`Ratomic::Pool` correctly implements ownership transfer:

```
Pool  -> Caller -> Pool
```

However, Redis clients contain internal state that cannot safely participate in ownership transfer after initialization. This resulted in failures such as:

```
Ractor::MovedError
```

Several approaches were explored, including pool reset behavior, but the underlying issue was resource ownership rather than resource cleanup.

## Solution

Introduce `Ratomic::LocalPool`.

Instead of moving live resources between Ractors, the facade remains shareable while each Ractor lazily creates and owns its own local resource pool.

Architecture:

```
LocalPool facade 
       ↓
Ractor-local pool
       ↓
Live resources
```

Calling this the "Inception Pool" design:

```
Pool
  ↓
Pool
  ↓
Resource
```
A Pool within a Pool :)

## Validation

Added Redis smoke tests covering:

### basic_redis.rb

* Thread execution
* Ractor execution
* Shared facade usage

### queue_redis.rb

* Multiple producers
* Multiple consumers
* Queue draining verification

Observed results:

* No `Ractor::MovedError`
* No `Ractor::IsolationError`
* Successful queue drain
* Successful operation from both Threads and Ractors
