### PR TITLE
Fix Map#compute deadlock under thread contention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+### Fixed
+
+- Prevent `Map#compute` from deadlocking when multiple Ruby threads contend for the same key.
+
 ## 0.4.1
 
 ### Documentation

--- a/ext/ratomic/src/hashmap.rs
+++ b/ext/ratomic/src/hashmap.rs
@@ -54,6 +54,21 @@ impl MapStore {
         self.map.len()
     }
 
+    fn with_entry<F, R, W>(&self, key: VALUE, mut on_locked: W, f: F) -> R
+    where
+        F: FnOnce(Entry<'_, RubyHashEql, VALUE>) -> R,
+        W: FnMut(),
+    {
+        let mut f = Some(f);
+        loop {
+            if let Some(entry) = self.map.try_entry(RubyHashEql(key)) {
+                return f.take().expect("entry closure already used")(entry);
+            }
+
+            on_locked();
+        }
+    }
+
     pub fn fetch_and_modify<F>(&self, key: VALUE, f: F)
     where
         F: FnOnce(VALUE) -> VALUE,
@@ -61,11 +76,18 @@ impl MapStore {
         self.map.alter(&RubyHashEql(key), |_, value| f(value));
     }
 
-    pub fn compute<F, E>(&self, key: VALUE, missing: VALUE, f: F) -> Result<VALUE, E>
+    pub fn compute<F, E, W>(
+        &self,
+        key: VALUE,
+        missing: VALUE,
+        on_locked: W,
+        f: F,
+    ) -> Result<VALUE, E>
     where
         F: FnOnce(VALUE) -> Result<VALUE, E>,
+        W: FnMut(),
     {
-        match self.map.entry(RubyHashEql(key)) {
+        self.with_entry(key, on_locked, |entry| match entry {
             Entry::Occupied(mut entry) => {
                 let new_value = f(*entry.get())?;
                 entry.insert(new_value);
@@ -76,7 +98,7 @@ impl MapStore {
                 entry.insert(new_value);
                 Ok(new_value)
             }
-        }
+        })
     }
 
     pub fn update<F, E>(&self, key: VALUE, f: F) -> Result<VALUE, E>

--- a/ext/ratomic/src/lib.rs
+++ b/ext/ratomic/src/lib.rs
@@ -18,7 +18,7 @@ use magnus::{
 use mpmc_queue::MpmcQueue;
 use parking_lot::Mutex;
 use rb_sys::{rb_ext_ractor_safe, rb_thread_call_without_gvl, ruby_special_consts, VALUE};
-use std::{ffi::c_void, mem::transmute};
+use std::{ffi::c_void, mem::transmute, time::Duration};
 
 fn value_to_raw(value: Value) -> VALUE {
     unsafe { transmute::<Value, VALUE>(value) }
@@ -36,6 +36,22 @@ fn make_shareable(ruby: &Ruby, value: Value) -> Result<Value, Error> {
     value.freeze();
     let ractor: RClass = ruby.class_object().const_get("Ractor")?;
     ractor.funcall("make_shareable", (value,))
+}
+
+unsafe extern "C" fn sleep_briefly_without_gvl(_: *mut c_void) -> *mut c_void {
+    std::thread::sleep(Duration::from_millis(1));
+    std::ptr::null_mut()
+}
+
+fn wait_for_entry_without_gvl() {
+    unsafe {
+        rb_thread_call_without_gvl(
+            Some(sleep_briefly_without_gvl),
+            std::ptr::null_mut(),
+            None,
+            std::ptr::null_mut(),
+        );
+    }
 }
 
 struct Counter(AtomicCounter);
@@ -158,10 +174,15 @@ impl HashMap {
         }
 
         let proc = ruby.block_proc()?;
-        let raw = rb_self.0.compute(value_to_raw(key), qnil_raw(), |value| {
-            proc.call::<_, Value>((unsafe { value_from_raw(value) },))
-                .map(value_to_raw)
-        })?;
+        let raw = rb_self.0.compute(
+            value_to_raw(key),
+            qnil_raw(),
+            wait_for_entry_without_gvl,
+            |value| {
+                proc.call::<_, Value>((unsafe { value_from_raw(value) },))
+                    .map(value_to_raw)
+            },
+        )?;
 
         Ok(unsafe { value_from_raw(raw) }.into_value_with(ruby))
     }

--- a/test/unit/test_map.rb
+++ b/test/unit/test_map.rb
@@ -213,6 +213,32 @@ class MapUnitTest < Minitest::Test
     refute map.key?(:processed)
   end
 
+  def test_compute_does_not_deadlock_when_threads_contend_for_same_key
+    map = Ratomic::Map.new
+    started = Queue.new
+    worker = Thread.new do
+      map.compute("foo") do
+        started << true
+        sleep 0.2
+        "bar"
+      end
+    end
+
+    started.pop
+
+    result = Timeout.timeout(2) do
+      map.compute("foo") do
+        sleep 0.2
+        "baz"
+      end
+    end
+
+    worker.join
+
+    assert_equal "baz", result
+    assert_equal "baz", map["foo"]
+  end
+
   def test_fetch_or_store_returns_existing_value_without_yielding
     map = Ratomic::Map.new
     map[:source] = "postgres"


### PR DESCRIPTION
## Summary

Fix `Ratomic::Map#compute` deadlocking when multiple Ruby threads contend for the same key.

When an entry is locked by another thread, `compute` now retries while releasing Ruby's GVL. This allows the thread executing the existing `compute` block to resume and release the entry lock.

## Testing

- Added a deterministic regression test for concurrent `Map#compute` calls on the same key
- Verified the original issue reproduction
- Ran 100 repeated contention scenarios
- Full suite: 117 runs, 2,322 assertions, 0 failures, 2 skips
- `cargo check` passes

Fixes #27