### PR TITLE
Add API tweaks to improve compatibility with the connection_pool gem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+### Added
+
+- Expose `Pool#size` and `LocalPool#size` and add `shutdown` aliases for connection pool compatibility.
+
 ## 0.4.2
 
 ### Fixed

--- a/lib/ratomic/local_pool.rb
+++ b/lib/ratomic/local_pool.rb
@@ -69,6 +69,7 @@ module Ratomic
   # @see Pool Use Pool for plain mutable Ruby values where ownership transfer
   #   is the desired safety model.
   class LocalPool
+    attr_reader :size
     # Create a per-Ractor local pool facade.
     #
     # @param size [Integer] maximum number of resources in each Ractor-local pool
@@ -127,6 +128,7 @@ module Ratomic
       pool.close
       nil
     end
+    alias_method :shutdown, :close
 
     # Minimal thread-safe resource pool used inside exactly one Ractor.
     class ResourcePool

--- a/lib/ratomic/pool.rb
+++ b/lib/ratomic/pool.rb
@@ -26,6 +26,7 @@ module Ratomic
   #     buffer << :change
   #   end
   class Pool
+    attr_reader :size
     # Create a pool and seed it with +size+ objects from the factory block.
     #
     # @param size [Integer] number of pooled objects to create up front
@@ -37,6 +38,7 @@ module Ratomic
       raise ArgumentError, "pool size must be positive" if size <= 0
       raise LocalJumpError, "no block given" unless block_given?
 
+      @size = size
       @timeout = timeout&.to_f
       @control = self.class.send(:new_control_ractor)
       size.times { @control.send([:checkin, yield], move: true) }
@@ -88,6 +90,8 @@ module Ratomic
     rescue Ractor::ClosedError, Ractor::Error
       nil
     end
+    # backwards compatibility with ConnectionPool
+    alias_method :shutdown, :close
 
     # Checkout an object, yield it, then move it back to the pool.
     #

--- a/sig/ratomic.rbs
+++ b/sig/ratomic.rbs
@@ -68,6 +68,8 @@ module Ratomic
 
     def with: () { (untyped object) -> untyped } -> untyped
     def close: () -> nil
+    def shutdown: () -> nil
+    def size: () -> Integer
   end
 
   class Pool
@@ -76,6 +78,8 @@ module Ratomic
     def checkout: () -> untyped
     def checkin: (untyped object) -> nil
     def close: () -> nil
+    def shutdown: () -> nil
+    def size: () -> Integer
     def with: () { (untyped object) -> untyped } -> untyped
   end
 end

--- a/test/test_local_pool.rb
+++ b/test/test_local_pool.rb
@@ -78,6 +78,15 @@ class TestLocalPool < Minitest::Test
     assert_nil pool.close
   end
 
+  def test_size_and_shutdown
+    pool = Ratomic::LocalPool.new(size: 3, factory: FACTORY)
+
+    pool.with { |_object| nil }
+
+    assert_equal 3, pool.size
+    assert_nil pool.shutdown
+  end
+
   def test_threads_share_current_local_pool
     pool = Ratomic::LocalPool.new(size: 1, timeout: 0.1, factory: FACTORY)
     object_ids = Queue.new

--- a/test/test_pool.rb
+++ b/test/test_pool.rb
@@ -18,12 +18,14 @@ class TestPool < Minitest::Test
       end
     end
 
+    assert_equal POOL_SIZE, POOL.size
     ractors.map { |ractor| ractor_value(ractor) }
     POOL_SIZE.times do
       POOL.checkout
     end
     # 100ms timeout
     refute POOL.checkout
+    POOL.shutdown
   end
 
 end


### PR DESCRIPTION
I'm working on ractor compatibility in Sidekiq, a heavy user of the connection_pool gem. With these tweaks, I'm able to
use LocalPool instead of ConnectionPool (and it appears to be faster also!)
